### PR TITLE
chore: Add ButterCMS redis exporter target

### DIFF
--- a/infrastructure/prometheus/prometheus.yml
+++ b/infrastructure/prometheus/prometheus.yml
@@ -25,3 +25,12 @@ scrape_configs:
       - targets: ['buttercms-postgres-exporter.internal.cke-cs-dev.com']
         labels:
           service: 'buttercms-postgres-exporter'
+  - job_name: buttercms-redis-exporter
+    metrics_path: /metrics
+    scheme: https
+    # Can be slow as it connects to different infrastructure
+    scrape_timeout: 5s
+    static_configs:
+      - targets: ['buttercms-redis-exporter.internal.cke-cs-dev.com']
+        labels:
+          service: 'buttercms-redis-exporter'


### PR DESCRIPTION
## Changelog

```
chore: Add ButterCMS redis exporter target

Create a static scrape target in the prometheus configuration to scrape
the ButterCMS redis exporter service. This new target gives us another
part of the ButterCMS infrastructure handled in our monitoring stack.

Touches: cksource/cs#19411

```

## Linked issues

-   Touches: cksource/cs#19411
