### PR TITLE
chore: Remove unused ckbox.io subdomain from certificate checks

### DIFF
--- a/src/checks/CERTIFICATES.ts
+++ b/src/checks/CERTIFICATES.ts
@@ -12,7 +12,6 @@ export const CERTIFICATES: Record<OrganizationName, string[]> = {
 		'https://ckbox.io',
 		'https://cdn.ckbox.io',
 		'https://download.ckbox.io',
-		'https://cdn-source.ckbox.io',
 
 		'https://ckeditor.com',
 		'https://builder-api.ckeditor.com',


### PR DESCRIPTION
## Changelog

```
chore: Remove unused ckbox.io subdomain from certificate checks

The cdn-source.ckbox.io is not used anymore, will be deleted with 
https://github.com/cksource/dns-infrastructure/pull/34

Touches: https://github.com/cksource/cs/issues/20306
Touches: https://github.com/cksource/dns-infrastructure/pull/34
```

## Linked issues

-   Touches: https://github.com/cksource/cs/issues/20306
