### PR TITLE
chore: Remove deployment of internal grafana

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,16 +53,6 @@ workflows:
               only: [master]
       - cs-orb/release_to_ecr:
           use_oidc_role: true
-          name: 'release_grafana'
-          image_name: it-tiugo-monitoring-grafana-service
-          version_callback: echo $(node -pe "require('./package.json').version")-$(git rev-parse HEAD | cut -c1-10)
-          dockerfile_path: ./docker/grafana/Dockerfile
-          requires: [run_tests]
-          filters:
-            branches:
-              only: [master]
-      - cs-orb/release_to_ecr:
-          use_oidc_role: true
           name: 'release_pushgateway'
           image_name: it-tiugo-monitoring-pushgateway-service
           version_callback: echo $(node -pe "require('./package.json').version")-$(git rev-parse HEAD | cut -c1-10)

--- a/.env.template
+++ b/.env.template
@@ -4,4 +4,3 @@ BASIC_AUTH_PASSWORD="pass" # password for basic auth used by Prometheus and Push
 
 PUSHGATEWAY_URL="http://pushgateway:9091"
 PROMETHEUS_URL="http://prometheus:9090"
-SLACK_WEBHOOK_URL="" # Webhook url used to send alerts and notifications to Slack

--- a/README.md
+++ b/README.md
@@ -7,24 +7,14 @@
 1. `pnpm run docker:start`
 3. Go to [Dashboards](http://localhost:3000/dashboards) and browse available dashboards.
 
-## Create/edit Grafana dashboards in UI
+## Create/edit Grafana dashboards
 
 1. [Login](http://localhost:3000/login) to Grafana as Admin (use credentials from `.env` file).
 2. Choose dashboard from [Dashboards](http://localhost:3000/dashboards) or create new one.
 3. Edit Dashboard and save changes by pressing "Save dashboard" button.
 4. Export changes. See the "[Exporting changes](#export-changes-made-in-grafana-UI)" section. 
 
-## Create/edit Grafana alerts in UI
-
-1. [Login](http://localhost:3000/login) to Grafana as Admin (use credentials from `.env` file).
-2. Modify/add some of below resources:
-   1. [Alert rules](http://localhost:3000/alerting/list) - verify results of tests
-   2. [Contact points](http://localhost:3000/alerting/notifications) - define where alert notifications can be sent
-   3. [Notification policies](http://localhost:3000/alerting/routes) - define which alerts should be sent to which contact points
-3. Make sure you saved changes in Grafana UI by pressing "Save" button for each modified resource.
-4. Save changes made in Grafana UI permanently. See the "[Exporting changes](#export-changes-made-in-grafana-ui)" section.
-
-*Note: Already created alert resources cannot be modified through UI. You can still adjust them by modifying files in `infrastructure/grafana/alerting/`.*
+These dashboards are used only for local development. Alerts and dashboards used by [Grafana Cloud}(https://tiugo.grafana.net) will not be updated this way.
 
 ## Export changes made in Grafana UI
 
@@ -33,7 +23,7 @@ Run exporting scripts in the root directory of this repo:
 node scripts/export-grafana-resources.mjs
 ```
 
-This will update the files in `infrastructure` folder. Commit this files to `master` branch to rebuild the Grafana image and update the service.
+This will update the files in `infrastructure` folder. You can commit these files to share the changes with other devs.
 
 ## First run
 

--- a/scripts/export-grafana-resources.mjs
+++ b/scripts/export-grafana-resources.mjs
@@ -25,10 +25,6 @@ const GRAFANA_PASSWORD = process.env.GF_SECURITY_ADMIN_PASSWORD;
 			JSON.stringify( dashboardData.dashboard, null, 2 )
 		);
 	}
-
-	const alerts = await request( '/api/v1/provisioning/alert-rules/export', { type: 'text' } );
-
-	fs.writeFileSync( './infrastructure/grafana/alerting/alerting_rules.yaml', alerts );
 } )();
 
 async function request( path, { type = 'json' } = {} ) {
@@ -46,4 +42,3 @@ async function request( path, { type = 'json' } = {} ) {
 
 	return res.json();
 }
-


### PR DESCRIPTION
## Changelog

```
chore: Remove deployment of internal grafana

We are using Grafana Cloud for dashboards and alerts and internal grafana as a 
tiugo-monitoring service is not needed. We are keeping the Dockerfile and 
dashboards in this repository to allow local development with local instance of 
grafana.

Touches: #33.
```

## Linked issues

-   Touches: #33.
