### PR TITLE
chore: Add ButterCMS fastly exporter target

### DIFF
--- a/infrastructure/prometheus/prometheus.yml
+++ b/infrastructure/prometheus/prometheus.yml
@@ -34,3 +34,12 @@ scrape_configs:
       - targets: ['buttercms-redis-exporter.internal.cke-cs-dev.com']
         labels:
           service: 'buttercms-redis-exporter'
+  - job_name: buttercms-fastly-exporter
+    metrics_path: /metrics
+    scheme: https
+    # Can be slow as it connects to different infrastructure
+    scrape_timeout: 5s
+    static_configs:
+      - targets: ['buttercms-fastly-exporter.internal.cke-cs-dev.com']
+        labels:
+          service: 'buttercms-fastly-exporter'


### PR DESCRIPTION
## Changelog

```
chore: Add ButterCMS fastly exporter target

Create a static scrape target in the prometheus configuration to scrape
the ButterCMS Fastly exporter service. It is a last piece of ButterCMS
infrastructure that can be monitored by the prometheus exporters.

Touches: cksource/cs#19411
```

## Linked issues

-   Closes: #0.
-   Touches: cksource/cs#19411
