### PR TITLE
chore: Rename preview-blog url to development-website

### DIFF
--- a/src/checks/CERTIFICATES.ts
+++ b/src/checks/CERTIFICATES.ts
@@ -21,7 +21,7 @@ export const CERTIFICATES: Record<OrganizationName, string[]> = {
 		'https://cke4.ckeditor.com',
 		'https://ckeditor-demo-preview-1.ckeditor.com',
 		'https://prev1.ckeditor.com',
-		'https://preview-blog.ckeditor.com',
+		'https://development-website.ckeditor.com',
 		'https://preview.ckeditor.com',
 		'https://svn.ckeditor.com',
 		'https://dev.ckeditor.com',


### PR DESCRIPTION
## Changelog

```
chore: Rename preview-blog url to development-website

preview-blog.ckeditor.com is renamed to development-website.ckeditor.com 
as the previous name was a little misleading and it was a true development 
environment and not only preview for blogs.

Touches: cksource/nova-ckeditor.com#3515.
```

## Linked issues

-   Touches: cksource/nova-ckeditor.com#3515.
